### PR TITLE
fix: Panic on reencoding offsets

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1435,7 +1435,7 @@ fn reencode_offsets<O: OffsetSizeTrait>(
             let size = size_of::<O>();
             offsets.slice_with_length(
                 data.offset() * size,
-                (data.offset() + data.len() + 1) * size,
+                (data.len() + 1) * size,
             )
         }
         _ => offset_slice.iter().map(|x| *x - *start_offset).collect(),
@@ -2569,6 +2569,35 @@ mod tests {
         }
 
         builder.finish()
+    }
+
+    #[test]
+    fn reencode_offsets_when_first_offset_is_not_zero() {
+        let original_list = generate_list_data::<i32>();
+        let original_data = original_list.into_data();
+        let slice_data = original_data.slice(75, 7);
+        let (new_offsets, original_start, length) = reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
+        assert_eq!(vec![0, 3, 6, 9, 12, 15, 18, 21], new_offsets.typed_data::<i32>());
+        assert_eq!(225, original_start);
+        assert_eq!(21, length);
+    }
+
+    #[test]
+    fn reencode_offsets_when_first_offset_is_zero() {
+        let mut ls = GenericListBuilder::<i32, _>::new(UInt32Builder::new());
+        // ls = [[], [35, 42]
+        ls.append(true);
+        ls.values().append_value(35);
+        ls.values().append_value(42);
+        ls.append(true);
+        let original_list = ls.finish();
+        let original_data = original_list.into_data();
+
+        let slice_data = original_data.slice(1, 1);
+        let (new_offsets, original_start, length) = reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
+        assert_eq!(vec![0, 2], new_offsets.typed_data::<i32>());
+        assert_eq!(0, original_start);
+        assert_eq!(2, length);
     }
 
     /// Ensure when serde full & sliced versions they are equal to original input.


### PR DESCRIPTION
Code was incorrectly defining the end of the offset slice to be the start + slice_length * 2 because slice_with_length adds the start to the end. This caused the encoded batches to be larger than they needed to be and would result in a panic for certain slices.


