### PR TITLE
fix(flight-sql): do not unwrap peeked stream in case nothing was sent

### DIFF
--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -737,7 +737,11 @@ where
         // we wrap this stream in a `Peekable` one, which allows us to peek at
         // the first message without discarding it.
         let mut request = request.map(PeekableFlightDataStream::new);
-        let cmd = Pin::new(request.get_mut()).peek().await.unwrap().clone()?;
+        let cmd = Pin::new(request.get_mut())
+            .peek()
+            .await
+            .ok_or_else(|| Status::invalid_argument("Empty stream"))?
+            .clone()?;
 
         let message = match Any::decode(&*cmd.flight_descriptor.unwrap().cmd)
             .map_err(decode_error_to_status)


### PR DESCRIPTION
- [x] upstream

# Copilot

This pull request modifies the error handling in the `where` function within the `arrow-flight/src/sql/server.rs` file. The change ensures that an empty stream is handled gracefully by returning an appropriate error status.

### Error handling improvement:
* Updated the `cmd` assignment to use `ok_or_else` for handling the case where the stream is empty, returning a `Status::invalid_argument` error with the message "Empty stream." This improves robustness and clarity in error handling.